### PR TITLE
Add ability to pass through columns to three models

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package contains staging models, designed to work simultaneously with our [
 Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions, or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ## Configuration
-By default, this package will run using your target database and the `salesforce` schema. If this is not where your Salesforce data is (perhaps your Salesforce schema is `salesforce_fivetran`), add the following configuration to your `dbt_project.yml` file:
+By default, this package will run using your target database and the `salesforce` schema. If this is not where your Salesforce data is (perhaps your Salesforce schema is `salesforce_fivetran`), add the following configuration to your `dbt_project.yml` file. You can also pass through additional columns for the account, opportunity, and user models.
 
 ```yml
 # dbt_project.yml
@@ -31,9 +31,15 @@ By default, this package will run using your target database and the `salesforce
 config-version: 2
 
 vars:
-  salesforce_source:
-    salesforce_database: your_database_name
-    salesforce_schema: your_schema_name
+    salesforce_source:
+        salesforce_database: your_database_name
+        salesforce_schema: your_schema_name
+        account_pass_through_columns:
+            - "custom_column_name"
+        opportunity_pass_through_columns:
+            - "custom_column_name"
+        user_pass_through_columns:
+            - "custom_column_name"
 ```
 
 ## Contributions

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'salesforce_source'
-version: '0.0.1'
+version: '0.0.2'
 
 require-dbt-version: [">=0.18.0", "<0.19.0"]
 
@@ -16,3 +16,9 @@ vars:
         opportunity: "{{ source('salesforce', 'opportunity') }}" 
         user: "{{ source('salesforce', 'user') }}"
         user_role: "{{ source('salesforce', 'user_role') }}"    
+
+        # If there are extra columns you wish to pass through for either
+        # the account or opportunity tables you may do so here:
+        account_pass_through_columns: []
+        opportunity_pass_through_columns: []
+        user_pass_through_columns: []

--- a/models/stg_salesforce_account.sql
+++ b/models/stg_salesforce_account.sql
@@ -13,6 +13,10 @@ with base as (
       industry,
       number_of_employees,
       account_source
+      {% if var('account_pass_through_columns') != [] %}
+      ,
+      {{ var('account_pass_through_columns') | join (", ")}}
+      {% endif %}
 
     from base
 

--- a/models/stg_salesforce_opportunity.sql
+++ b/models/stg_salesforce_opportunity.sql
@@ -25,6 +25,10 @@ with base as (
         {{ dbt_utils.datediff('close_date', 'created_date', 'day') }} as days_to_close,
         {{ dbt_utils.date_trunc('month', 'close_date') }} = {{ dbt_utils.date_trunc('month', dbt_utils.current_timestamp()) }} as is_closed_this_month,
         {{ dbt_utils.date_trunc('quarter', 'close_date') }} = {{ dbt_utils.date_trunc('quarter', dbt_utils.current_timestamp()) }} as is_closed_this_quarter
+        {% if var('opportunity_pass_through_columns') != [] %}
+        ,
+        {{ var('opportunity_pass_through_columns') | join (", ")}}
+        {% endif %}
 
     from base
 

--- a/models/stg_salesforce_user.sql
+++ b/models/stg_salesforce_user.sql
@@ -12,6 +12,10 @@ with base as (
       state,
       manager_id,
       user_role_id
+      {% if var('user_pass_through_columns') != [] %}
+      ,
+      {{ var('user_pass_through_columns') | join (", ")}}
+      {% endif %}
     from base
 
 )


### PR DESCRIPTION
Inspiration for how this is implemented: https://github.com/fishtown-analytics/segment/pull/19/files

[Link to an issue I created earlier for this.](https://github.com/fivetran/dbt_salesforce_source/issues/1)

#### Testing these changes.

I installed the local version of the package in my project:

```
packages:
  - local: /Users/jacobmulligan/codes/dbt_salesforce_source
```

And set up the pass through vars in our `dbt_project.yml` file:
```
  salesforce_source:
    salesforce_database: raw
    salesforce_schema: salesforce
    opportunity_pass_through_columns:
      - 'TYPE'
      - 'NEXT_STEP'

    account_pass_through_columns:
      - 'WEBSITE'
      - 'PHONE'

    user_pass_through_columns:
      - 'EMAIL'
```

Then ran `dbt run` locally and the SalesForce models built successfully:

<img width="799" alt="Pasted_Image_11_4_20__10_06_PM" src="https://user-images.githubusercontent.com/1261230/98193097-62945180-1eea-11eb-9c91-4613ca9521f0.png">

And here's what the data looks like in Snowflake for the opportunity_enhanced view:

![image](https://user-images.githubusercontent.com/1261230/98193188-91aac300-1eea-11eb-9706-f31e6e20d56d.png)

