### PR TITLE
doc(salesforce source README): modeling to transform change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package enriches your Fivetran data by doing the following:
 
 ## Models
 
-This package contains staging models, designed to work simultaneously with our [Salesforce modeling package](https://github.com/fivetran/dbt_salesforce).  The staging models:
+This package contains staging models, designed to work simultaneously with our [Salesforce transform package](https://github.com/fivetran/dbt_salesforce).  The staging models:
 * Remove any rows that are soft-deleted
 * Name columns consistently across all packages:
     * Boolean fields are prefixed with `is_` or `has_`


### PR DESCRIPTION
Links https://fivetran.atlassian.net/browse/RD-190128

Changes mention of "modeling package" into "transform package."